### PR TITLE
Fix: Adding state to handle initial startup phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Used to get the current start status. This method returns a promise that resolve
 
 The state can return as `active`, `disabled`, `unavailable` or `unknown`, and if set to `disabled` will contain the type presenting the reason why.
 
+The type can return as `bluetooth`, `exposure`, `resolution`, `paused`, `starting` and its meaning should be read in combination with `state`, i.e. a state of `disabled` and a type of `bluetooth` indicates that ENS is disabled because bluetooth is off.
+
 State changes also trigger the event `onStatusChanged`.
 
 ---

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -116,7 +116,7 @@ class Tracing {
 
         var status = STATUS_STOPPED
         private var exposureStatus = EXPOSURE_STATUS_UNAVAILABLE
-        private var exposureDisabledReason = "initialising"
+        private var exposureDisabledReason = "starting"
 
         private lateinit var exposureWrapper: ExposureNotificationClientWrapper
 

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -406,17 +406,17 @@ class Tracing {
                                 promise.resolve("granted")
                             } else {
                                 Events.raiseEvent(Events.INFO,"isAuthorised: denied")
-                                promise.resolve("denied")
+                                promise.resolve("blocked")
                             }
                         }
                         .addOnFailureListener { ex ->
                             Events.raiseError("isAuthorised - onFailure", ex)
                             handleApiException(ex)
-                            promise.resolve("denied")
+                            promise.resolve("blocked")
                         }
             } catch (ex: Exception) {
                 Events.raiseError("isAuthorised - exception", ex)
-                promise.resolve("denied")
+                promise.resolve("blocked")
             }
         }
 

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -115,8 +115,8 @@ class Tracing {
         private const val STATUS_STOPPING = "STOPPING"
 
         var status = STATUS_STOPPED
-        private var exposureStatus = EXPOSURE_STATUS_UNKNOWN
-        private var exposureDisabledReason = ""
+        private var exposureStatus = EXPOSURE_STATUS_UNAVAILABLE
+        private var exposureDisabledReason = "initialising"
 
         private lateinit var exposureWrapper: ExposureNotificationClientWrapper
 

--- a/ios/ExposureProcessor.swift
+++ b/ios/ExposureProcessor.swift
@@ -95,7 +95,7 @@ public class ExposureProcessor {
             result["type"] = "paused"
         default:
             result["state"] = "unavailable"
-            result["type"] = "initialising"
+            result["type"] = "starting"
       }
       os_log("Status is %d", log: OSLog.checkExposure, type: .debug, ExposureManager.shared.manager.exposureNotificationStatus.rawValue)
       

--- a/ios/ExposureProcessor.swift
+++ b/ios/ExposureProcessor.swift
@@ -90,8 +90,12 @@ public class ExposureProcessor {
             result["type"] = ["bluetooth"]
         case .restricted:
             result["state"] = "restricted"
+        case .paused:
+            result["state"] = "disabled"
+            result["type"] = "paused"
         default:
             result["state"] = "unavailable"
+            result["type"] = "initialising"
       }
       os_log("Status is %d", log: OSLog.checkExposure, type: .debug, ExposureManager.shared.manager.exposureNotificationStatus.rawValue)
       

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [

--- a/src/__tests__/exposure-provider.test.tsx
+++ b/src/__tests__/exposure-provider.test.tsx
@@ -56,6 +56,9 @@ jest.mock('../exposure-notification-module', () => ({
   StatusType: {
     starting: 'starting'
   },
+  AuthorisedStatus: {
+    unknown: 'unknown'
+  },
   authoriseExposure: jest.fn().mockResolvedValue(true),
   configure: jest.fn().mockResolvedValue(true),
   start: jest.fn().mockResolvedValue(true),

--- a/src/__tests__/exposure-provider.test.tsx
+++ b/src/__tests__/exposure-provider.test.tsx
@@ -51,7 +51,10 @@ jest.mock('../utils/permissions', () => ({
 
 jest.mock('../exposure-notification-module', () => ({
   StatusState: {
-    unknown: 'unknown'
+    unavailable: 'unavailable'
+  },
+  StatusType: {
+    starting: 'starting'
   },
   authoriseExposure: jest.fn().mockResolvedValue(true),
   configure: jest.fn().mockResolvedValue(true),
@@ -242,7 +245,7 @@ describe('useExposure', () => {
       getCloseContacts: expect.any(Function),
       getDiagnosisKeys: expect.any(Function),
       getLogData: expect.any(Function),
-      initialised: false,
+      initialised: true,
       isAuthorised: true,
       permissions: {
         exposure: {

--- a/src/exposure-notification-module.ts
+++ b/src/exposure-notification-module.ts
@@ -36,6 +36,7 @@ export interface CloseContact {
 }
 
 export enum StatusState {
+  unavailable = 'unavailable',
   unknown = 'unknown',
   restricted = 'restricted',
   disabled = 'disabled',
@@ -45,7 +46,9 @@ export enum StatusState {
 export enum StatusType {
   bluetooth = 'bluetooth',
   exposure = 'exposure',
-  resolution = 'resolution'
+  resolution = 'resolution',
+  paused = 'paused',
+  initialising = 'initialising'
 }
 
 export interface Status {

--- a/src/exposure-notification-module.ts
+++ b/src/exposure-notification-module.ts
@@ -48,7 +48,7 @@ export enum StatusType {
   exposure = 'exposure',
   resolution = 'resolution',
   paused = 'paused',
-  initialising = 'initialising'
+  starting = 'starting'
 }
 
 export interface Status {

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -191,7 +191,7 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
       supported: is,
       isAuthorised
     }));
-
+    await validateStatus(status)
     if (enabled) {
       await configure();
       getCloseContacts();
@@ -201,10 +201,12 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   const validateStatus = async (status?: Status) => {
     let newStatus = status || ((await ExposureNotification.status()) as Status);
     const enabled = await ExposureNotification.exposureEnabled();
+    const isAuthorised = await ExposureNotification.isAuthorised();
+    const canSupport = await ExposureNotification.canSupport();
 
-    const isStarting = state.isAuthorised === AuthorisedStatus.unknown && newStatus.state === StatusState.unavailable && newStatus.type?.includes(StatusType.starting)
-    const initialised = !isStarting || !state.canSupport
-    setState((s) => ({...s, status: newStatus, enabled, initialised}));
+    const isStarting = (isAuthorised === AuthorisedStatus.unknown || isAuthorised === AuthorisedStatus.granted) && newStatus.state === StatusState.unavailable && newStatus.type?.includes(StatusType.starting)
+    const initialised = !isStarting || !canSupport
+    setState((s) => ({...s, status: newStatus, enabled, isAuthorised, canSupport, initialised}));
   };
 
   const start = async () => {

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -65,7 +65,7 @@ export interface ExposureContextValue extends State {
 const initialState = {
   status: {
     state: StatusState.unavailable,
-    type: StatusType.initialising
+    type: [StatusType.initialising]
   },
   supported: false,
   canSupport: false,

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -156,13 +156,6 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
     };
   }, []);
 
-  const clearAndResetTimer = (timerRef: any) => {
-    if (timerRef && timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  };
-
   useEffect(() => {
     async function checkSupportAndStart() {
       await supportsExposureApi();
@@ -175,21 +168,10 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
         await configure();
         start();
       }
-
-      if (state.status.state === StatusState.unknown) {
-        clearAndResetTimer(unknownStatusTimer);
-        unknownStatusTimer.current = setTimeout(() => {
-          setState((s) => ({...s, initialised: true}));
-        }, 5000);
-      } else {
-        clearAndResetTimer(unknownStatusTimer);
-        setState((s) => ({...s, initialised: true}));
-      }
     }
 
     checkSupportAndStart();
 
-    return () => clearAndResetTimer(unknownStatusTimer);
   }, [state.permissions, isReady]);
 
   const supportsExposureApi = async function () {

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -65,7 +65,7 @@ export interface ExposureContextValue extends State {
 const initialState = {
   status: {
     state: StatusState.unavailable,
-    type: [StatusType.initialising]
+    type: [StatusType.starting]
   },
   supported: false,
   canSupport: false,
@@ -201,7 +201,8 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   const validateStatus = async (status?: Status) => {
     let newStatus = status || ((await ExposureNotification.status()) as Status);
     const enabled = await ExposureNotification.exposureEnabled();
-    setState((s) => ({...s, status: newStatus, enabled}));
+    const initialised = !(newStatus.state === StatusState.unavailable && newStatus.type?.includes(StatusType.starting))
+    setState((s) => ({...s, status: newStatus, enabled, initialised}));
   };
 
   const start = async () => {

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -201,7 +201,9 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   const validateStatus = async (status?: Status) => {
     let newStatus = status || ((await ExposureNotification.status()) as Status);
     const enabled = await ExposureNotification.exposureEnabled();
-    const initialised = !(newStatus.state === StatusState.unavailable && newStatus.type?.includes(StatusType.starting))
+
+    const isStarting = state.isAuthorised === AuthorisedStatus.unknown && newStatus.state === StatusState.unavailable && newStatus.type?.includes(StatusType.starting)
+    const initialised = !isStarting || !state.canSupport
     setState((s) => ({...s, status: newStatus, enabled, initialised}));
   };
 

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -130,8 +130,6 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   const [state, setState] = useState<State>(initialState);
   const unknownStatusTimer = useRef<any>(null);
 
-  let subscription = emitter.addListener('exposureEvent', handleEvent);
-
   useEffect(() => {
     function handleEvent(
       ev: {onStatusChanged?: Status; status?: any; scheduledTask?: any} = {}
@@ -142,6 +140,7 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
       }
     }
 
+    let subscription = emitter.addListener('exposureEvent', handleEvent);
 
     const listener = (type: AppStateStatus) => {
       if (type === 'active') {

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -19,7 +19,8 @@ import ExposureNotification, {
   AuthorisedStatus,
   StatusState,
   Status,
-  CloseContact
+  CloseContact,
+  StatusType
 } from './exposure-notification-module';
 
 import {getPermissions, requestPermissions} from './utils/permissions';
@@ -63,7 +64,8 @@ export interface ExposureContextValue extends State {
 
 const initialState = {
   status: {
-    state: StatusState.unknown
+    state: StatusState.unavailable,
+    type: StatusType.initialising
   },
   supported: false,
   canSupport: false,
@@ -128,6 +130,8 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   const [state, setState] = useState<State>(initialState);
   const unknownStatusTimer = useRef<any>(null);
 
+  let subscription = emitter.addListener('exposureEvent', handleEvent);
+
   useEffect(() => {
     function handleEvent(
       ev: {onStatusChanged?: Status; status?: any; scheduledTask?: any} = {}
@@ -138,7 +142,6 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
       }
     }
 
-    let subscription = emitter.addListener('exposureEvent', handleEvent);
 
     const listener = (type: AppStateStatus) => {
       if (type === 'active') {


### PR DESCRIPTION
Currently the module reports an ENS status of `unknown` as the module is starting. However `unknown` is also a valid state after the module has started.
This is resulting in UIs briefly displaying an incorrect status on startup.

This fix adds an initialising state that apps can detect and utilise to avoid showing incorrect ENS status as app starts