### PR TITLE
Fix: Restart background processing scheduling when app restarted in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,10 +374,6 @@ function Root() {
 
 `boolean` (default `false`) Consent to send analytics to your exposure API's `/metrics` endpoint
 
-##### `debug` (optional)
-
-`boolean` use the `ExposureNotificationModule` in debug mode
-
 ### `useExposure`
 
 Use the `useExposure` hook in any component to consume the `ExposureProvider` context & methods

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,11 +119,6 @@ dependencies {
 
     implementation 'androidx.concurrent:concurrent-futures:1.0.0'
 
-    // play services included in aar
-    // .m2/repository early-access-programme
-    //implementation 'com.google.android.gms:play-services-nearby:18.0.2-eap'
-    //real when available
-    //implementation 'com.google.android.gms:play-services-nearby:18.0.2'
     implementation 'com.google.android.gms:play-services-base:17.2.1'
     implementation 'com.google.android.gms:play-services-basement:17.2.1'
     implementation 'com.google.android.gms:play-services-safetynet:17.0.0'

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -245,7 +245,7 @@ class Tracing {
             } else if (status === STATUS_STOPPED) {
                 setExposureStatus(EXPOSURE_STATUS_DISABLED, "exposure")
             }
-            Events.raiseEvent(Events.STATUS, status)
+            Events.raiseEvent(Events.ON_STATUS_CHANGED, status)
         }
 
         @JvmStatic

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -524,8 +524,7 @@ class Tracing {
             }
         }
 
-        @JvmStatic
-        fun scheduleCheckExposure() {
+        private fun scheduleCheckExposure() {
             try {
                 // stop and re-start with config value
                 ProvideDiagnosisKeysWorker.stopScheduler()

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -203,10 +203,7 @@ class Tracing {
             override fun onSuccess(message: String) {
                 try {
                     Events.raiseEvent(Events.INFO, "authorisationCallback - success")
-                    // only start scheduler if starting, this path occurs during authorisation too
-                    // so we dont start sceduler when just authorising
                     if (status == STATUS_STARTING) {
-                        ProvideDiagnosisKeysWorker.startScheduler()
                         setNewStatus(STATUS_STARTED)
                         startPromise?.resolve(true)
                     } else {
@@ -317,7 +314,7 @@ class Tracing {
                 Config.configure(params)
                 val newCheckFrequency = getLong("exposureCheckFrequency", context)
 
-                if(newCheckFrequency != oldCheckFrequency && status == STATUS_STARTED) {
+                if(newCheckFrequency != oldCheckFrequency) {
                     scheduleCheckExposure()
                 }
             } catch (ex: Exception) {
@@ -525,7 +522,8 @@ class Tracing {
             }
         }
 
-        private fun scheduleCheckExposure() {
+        @JvmStatic
+        fun scheduleCheckExposure() {
             try {
                 // stop and re-start with config value
                 ProvideDiagnosisKeysWorker.stopScheduler()

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -231,6 +231,8 @@ class Tracing {
                 exposureWrapper = ExposureNotificationClientWrapper.get(context)
                 reactContext.addActivityEventListener(Listener())
                 currentContext = context // this is overridden depending on path into codebase
+
+                scheduleCheckExposure()
             } catch (ex: Exception) {
                 Events.raiseError("init", ex)
             }

--- a/android/src/main/java/ie/gov/tracing/common/Config.kt
+++ b/android/src/main/java/ie/gov/tracing/common/Config.kt
@@ -6,7 +6,6 @@ import ie.gov.tracing.storage.SharedPrefs
 
 class Config {
     companion object {
-        var debug = false
         fun configure(params: ReadableMap) {
             try {
                 Events.raiseEvent(Events.INFO, "Saving configuration...")
@@ -22,8 +21,6 @@ class Config {
                 SharedPrefs.setString("refreshToken", params.getString("refreshToken")!!, Tracing.context)
                 SharedPrefs.setString("authToken", params.getString("authToken")!!, Tracing.context)
                 SharedPrefs.setString("callbackNumber", params.getString("callbackNumber")!!, Tracing.context)
-                
-                debug = params.getBoolean("debug")
             } catch(ex: Exception) {
                 Events.raiseError("Error setting configuration: ", ex)
             }

--- a/android/src/main/java/ie/gov/tracing/common/Events.kt
+++ b/android/src/main/java/ie/gov/tracing/common/Events.kt
@@ -21,7 +21,7 @@ class Events {
         const val ON_STATUS_CHANGED = "onStatusChanged" // tracing api status
         const val ON_EXPOSURE = "exposure"
 
-        private const val TAG = "RNExposureNotification"
+        private const val TAG = "RNExposureNotificationService"
 
         private fun raiseEvent(map: ReadableMap) {
             Tracing.reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)?.emit("exposureEvent", map)
@@ -33,7 +33,7 @@ class Events {
                 isDebuggable = 0 != Tracing.currentContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE
             } catch (ex: Exception) {}
 
-            if (isDebuggable || Config.debug) return true // allow all events in debug
+            if (isDebuggable) return true // allow all events in debug
             if(eventName == ON_STATUS_CHANGED || eventName == ON_EXPOSURE) return true // allow these debug or release
 
             return false
@@ -41,6 +41,7 @@ class Events {
 
         @JvmStatic
         fun raiseEvent(eventName: String, eventValue: String?): Boolean {
+            Log.d(TAG, eventValue)
             if(!allowed(eventName)) return false
             val map = Arguments.createMap()
             try {

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -111,6 +111,13 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
       SharedPrefs.remove("lastApiError", Tracing.currentContext);
       SharedPrefs.remove("lastError", Tracing.currentContext);
 
+      // validate config set before running
+      final String auth = SharedPrefs.getString("authToken", this.getApplicationContext());
+      if (authToken.isEmpty()) {
+        // config not yet populated so don't run
+        return Futures.immediateFailedFuture(new NotEnabledException());
+      }
+
       deleteOldData();
 
       final String token = generateRandomToken();
@@ -228,12 +235,10 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
   }
 
   public static void startScheduler() {
-    /*if(isWorkScheduled()) {
-      Events.raiseEvent(Events.INFO, "ProvideDiagnosisKeysWorker.startScheduler: already scheduled");
-      return;
-    }*/
-
     long checkFrequency = SharedPrefs.getLong("exposureCheckFrequency", Tracing.context);
+    if (checkFrequency <= 0) {
+      checkFrequency = 120;
+    }
     Events.raiseEvent(Events.INFO, "ProvideDiagnosisKeysWorker.startScheduler: run every " +
             checkFrequency + " minutes");
     WorkManager workManager = WorkManager.getInstance(Tracing.context);

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -113,7 +113,7 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
 
       // validate config set before running
       final String auth = SharedPrefs.getString("authToken", this.getApplicationContext());
-      if (authToken.isEmpty()) {
+      if (auth.isEmpty()) {
         // config not yet populated so don't run
         return Futures.immediateFailedFuture(new NotEnabledException());
       }

--- a/android/src/main/java/ie/gov/tracing/network/Fetcher.kt
+++ b/android/src/main/java/ie/gov/tracing/network/Fetcher.kt
@@ -194,7 +194,6 @@ class Fetcher {
                 val notificationSent = SharedPrefs.getLong("notificationSent", context)
                 var callbackNum = SharedPrefs.getString("callbackNumber", context)
 
-
                 if (notificationSent > 0) {
                     Events.raiseEvent(Events.INFO, "triggerCallback - notification " +
                             "already sent: " + notificationSent)
@@ -206,6 +205,10 @@ class Fetcher {
                     try {
                         val store = ExpoSecureStoreInterop(context)
                         val jsonStr = store.getItemImpl("cti.callBack")
+                        if (jsonStr.isEmpty()) {
+                            Events.raiseEvent(Events.INFO, "triggerCallback - no callback recovery")
+                            return;
+                        }
                         val callBackData = Gson().fromJson(jsonStr, CallbackRecovery::class.java)
 
                         if(callBackData.code == null || callBackData.number == null){
@@ -213,8 +216,6 @@ class Fetcher {
                             return;
                         }
                         callbackNum = callBackData.code +  callBackData.number
-
-
                     } catch (exExpo: Exception) {
                         Events.raiseError("ExpoSecureStoreInterop", exExpo)
                     }

--- a/ios/ExposureCheck.swift
+++ b/ios/ExposureCheck.swift
@@ -93,6 +93,11 @@ class ExposureCheck: AsyncOperation {
             return
        }
         
+       guard ExposureManager.shared.manager.exposureNotificationEnabled else {
+            self.finishNoProcessing("Exposure notifications not enabled")
+            return
+       }
+
        self.configData = Storage.shared.readSettings(self.storageContext)
        guard self.configData != nil else {
           self.finishNoProcessing("No config set so can't proceeed with checking exposures")

--- a/ios/ExposureProcessor.swift
+++ b/ios/ExposureProcessor.swift
@@ -121,8 +121,6 @@ public class ExposureProcessor {
                 resolve(true)
             }
         }
-        
-        scheduleCheckExposure()
     }
     
     public func stop(_ resolve: @escaping RCTPromiseResolveBlock,
@@ -247,6 +245,8 @@ public class ExposureProcessor {
                 ExposureProcessor.shared.checkExposureBackground(task as! BGProcessingTask)
         }
         os_log("Registering background task", log: OSLog.exposure, type: .debug)
+        
+        self.scheduleCheckExposure()
     }
     
     private func checkExposureBackground(_ task: BGTask) {
@@ -283,11 +283,6 @@ public class ExposureProcessor {
     
     private func scheduleCheckExposure() {
       let context = Storage.PersistentContainer.shared.newBackgroundContext()
-      guard ENManager.authorizationStatus == .authorized else {
-           os_log("Not authorised so can't schedule exposure checks", log: OSLog.exposure, type: .info)
-           Storage.shared.updateRunData(context, "Not authorised so can't schedule exposure checks")
-           return
-      }
       
       do {
           let request = BGProcessingTaskRequest(identifier: self.backgroundName)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [

--- a/src/__tests__/exposure-provider.test.tsx
+++ b/src/__tests__/exposure-provider.test.tsx
@@ -94,8 +94,7 @@ const mockConfig = {
   notificationTitle: 'testNotificationTitle',
   notificationDescription: 'testNotificationDescription',
   analyticsOptin: true,
-  callbackNumber: '0123456789',
-  debug: false
+  callbackNumber: '0123456789'
 };
 
 const ExposureProviderWithMockConfig: React.FC<Partial<
@@ -197,7 +196,6 @@ describe('<ExposureProvider />', () => {
       analyticsOptin: mockConfig.analyticsOptin,
       authToken: mockConfig.authToken,
       callbackNumber: mockConfig.callbackNumber,
-      debug: mockConfig.debug,
       exposureCheckFrequency:
         mockConfig.traceConfiguration.exposureCheckInterval,
       fileLimit: mockConfig.traceConfiguration.fileLimitiOS,
@@ -353,7 +351,6 @@ describe('useExposure', () => {
         analyticsOptin: mockConfig.analyticsOptin,
         authToken: mockConfig.authToken,
         callbackNumber: mockConfig.callbackNumber,
-        debug: mockConfig.debug,
         exposureCheckFrequency:
           mockConfig.traceConfiguration.exposureCheckInterval,
         fileLimit: mockConfig.traceConfiguration.fileLimitiOS,

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -110,7 +110,6 @@ export interface ExposureProviderProps {
   notificationDescription: string;
   callbackNumber?: string;
   analyticsOptin?: boolean;
-  debug?: boolean;
 }
 
 export const ExposureProvider: React.FC<ExposureProviderProps> = ({
@@ -125,7 +124,6 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   notificationDescription,
   callbackNumber = '',
   analyticsOptin = false,
-  debug = false
 }) => {
   const [state, setState] = useState<State>(initialState);
   const unknownStatusTimer = useRef<any>(null);

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -248,9 +248,6 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
         notificationDesc: notificationDescription,
         callbackNumber,
         analyticsOptin,
-        // this is an undocumented param
-        // @ts-ignore
-        debug
       };
 
       await ExposureNotification.configure(config);

--- a/test-app/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/test-app/android/app/src/main/java/com/testapp/MainApplication.java
@@ -81,8 +81,6 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
 
-    Tracing.scheduleCheckExposure();
-
     if (!BuildConfig.DEBUG) {
       UpdatesController.initialize(this);
     }

--- a/test-app/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/test-app/android/app/src/main/java/com/testapp/MainApplication.java
@@ -26,6 +26,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
+import ie.gov.tracing.Tracing;
 
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
@@ -79,6 +80,8 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+
+    Tracing.scheduleCheckExposure();
 
     if (!BuildConfig.DEBUG) {
       UpdatesController.initialize(this);

--- a/test-app/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/test-app/android/app/src/main/java/com/testapp/MainApplication.java
@@ -26,7 +26,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
-import ie.gov.tracing.Tracing;
 
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(

--- a/test-app/android/build.gradle
+++ b/test-app/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath('com.android.tools.build:gradle:4.0.1')
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/test-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Aug 17 09:48:52 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
When a phone reboots or background processing is killed by power management  the background processing scheduling was not restarting when app was relaunched in background mode.

Fix correctly restarts background scheduling.