### PR TITLE
Fix: Status event using incorrect status name

### DIFF
--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -245,7 +245,7 @@ class Tracing {
             } else if (status === STATUS_STOPPED) {
                 setExposureStatus(EXPOSURE_STATUS_DISABLED, "exposure")
             }
-            Events.raiseEvent(Events.ON_STATUS_CHANGED, status)
+            Events.raiseEvent(Events.STATUS, status)
         }
 
         @JvmStatic

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
v1.1.18 introduced a bug in relation to status event. This PR is to fix that issue