### PR TITLE
Adding ability to capture client errors and log server side

### DIFF
--- a/android/src/main/java/ie/gov/tracing/common/Events.kt
+++ b/android/src/main/java/ie/gov/tracing/common/Events.kt
@@ -71,6 +71,10 @@ class Events {
         @JvmStatic
         fun raiseError(message: String, ex: Exception) {
             try {
+                HashMap<String, Object> payload = new HashMap<>();
+                payload.put("description", "$message: $ex");
+                Fetcher.saveMetric("LOG_ERROR", Tracing.currentContext, payload);
+
                 if(allowed(ERROR)) { // if debugging allow stacktrace
                     var sw = StringWriter()
                     val pw = PrintWriter(sw)
@@ -83,6 +87,7 @@ class Events {
                     SharedPrefs.setString("lastError", "$ex - $sw", Tracing.currentContext)
                     raiseEvent(ERROR, "$message: $ex - $sw")
                 } else { // otherwise just log generic message
+
                     Log.e(TAG, "error: $ex")
                 }
             } catch (ex: Exception) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Uses the metric end point to add the ability to capture client errors and log them to server.

Also corrects the DAILY_ACTIVE_TRACE metric so that it will fire every day