### PR TITLE
Fixing bearer token bug 

### DIFF
--- a/ios/ExposureCheck.swift
+++ b/ios/ExposureCheck.swift
@@ -725,8 +725,8 @@ class RequestInterceptor: Alamofire.RequestInterceptor {
 
         var urlRequest = urlRequest
 
-        let keyServerHost = Storage.getDomain(self.config.keyServerUrl)
-        if (urlRequest.url?.host == keyServerHost && self.config.keyServerType == Storage.KeyServerType.NearForm) {
+        let nfServer = Storage.getDomain(self.config.serverURL)
+        if (urlRequest.url?.host == nfServer) {
             /// Set the Authorization header value using the access token, only on nearform server requests
             urlRequest.setValue("Bearer " + self.config.authToken, forHTTPHeaderField: "Authorization")
         }
@@ -735,7 +735,7 @@ class RequestInterceptor: Alamofire.RequestInterceptor {
     }
 
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401, request.retryCount == 0 else {
             /// The request did not fail due to a 401 Unauthorized response.
             /// Return the original error and don't retry the request.
             return completion(.doNotRetryWithError(error))

--- a/ios/Storage.swift
+++ b/ios/Storage.swift
@@ -352,9 +352,9 @@ public class Storage {
           return info
         }
       } catch  {
-        os_log("Could not retrieve settings: %@", log: OSLog.storage, type: .error, error.localizedDescription)
+        os_log("Could not retrieve exposures: %@", log: OSLog.storage, type: .error, error.localizedDescription)
       }
-      os_log("Fetching settings from store", log: OSLog.storage, type: .debug)
+      /// os_log("Fetching exposures from store", log: OSLog.storage, type: .debug)
 
       return exposures
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
on iOS  a 401 response was triggering a repeated loop to refresh token