### PR TITLE
Ios check fix

### DIFF
--- a/ios/ExposureCheck.swift
+++ b/ios/ExposureCheck.swift
@@ -105,11 +105,6 @@ class ExposureCheck: AsyncOperation {
           self.finishNoProcessing("No config set so can't proceeed with checking exposures", false)
           return
        }
-
-       guard ENManager.authorizationStatus == .authorized else {
-            self.finishNoProcessing("Not authorised so can't run exposure checks")
-            return
-       }
       
        let serverDomain: String = Storage.getDomain(self.configData.serverURL)
        let keyServerDomain: String = Storage.getDomain(self.configData.keyServerUrl)
@@ -129,7 +124,12 @@ class ExposureCheck: AsyncOperation {
             self.finishNoProcessing("Check was run at \(formatter.string(from: self.configData.lastRunDate!)), interval is \(self.configData.checkExposureInterval), its too soon to check again", false)
             return
        }
-      
+
+       guard ENManager.authorizationStatus == .authorized else {
+            self.finishNoProcessing("Not authorised so can't run exposure checks")
+            return
+       }
+
        // clean out any expired exposures
        Storage.shared.deleteOldExposures(self.configData.storeExposuresFor)
         
@@ -679,7 +679,7 @@ class ExposureCheck: AsyncOperation {
     }
     guard self.configData != nil else {
       // don't track daily trace if config not setup
-      return self.finish()
+      return completion(.success(true))
     }
 
     if (!self.configData.analyticsOptin) {

--- a/ios/ExposureProcessor.swift
+++ b/ios/ExposureProcessor.swift
@@ -121,6 +121,7 @@ public class ExposureProcessor {
                 resolve(true)
             }
         }
+        self.scheduleCheckExposure()
     }
     
     public func stop(_ resolve: @escaping RCTPromiseResolveBlock,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
If ENS is not authorised this error was being logged but AlamoFire had not been configured so a crash occurred.

This PR corrects this.

Also adds a call to scheduleExposure after ENS is enabled to ensure background processing runs.