### PR TITLE
build: fix broken deployment due to older version of gms as dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,10 +121,11 @@ dependencies {
 
     implementation 'androidx.concurrent:concurrent-futures:1.0.0'
 
-    implementation 'com.google.android.gms:play-services-base:17.2.1'
-    implementation 'com.google.android.gms:play-services-basement:17.2.1'
+    implementation 'com.google.android.gms:play-services-base:17.4.0'
+    implementation 'com.google.android.gms:play-services-basement:17.4.0'
+    implementation 'com.google.android.gms:play-services-tasks:17.2.0'
+
     implementation 'com.google.android.gms:play-services-safetynet:17.0.0'
-    implementation 'com.google.android.gms:play-services-tasks:17.0.2'
     implementation 'com.google.android.gms:play-services-vision:20.0.0'
 
     implementation 'com.jakewharton.threetenabp:threetenabp:1.2.4'

--- a/android/src/main/java/ie/gov/tracing/nearby/StateUpdatedWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/StateUpdatedWorker.java
@@ -248,7 +248,6 @@ public class StateUpdatedWorker extends ListenableWorker {
     showNotification(context);
   }
 
-   @RequiresApi(api = Build.VERSION_CODES.O)
    public static void simulateExposure(Long timeDelay) {
         Events.raiseEvent(Events.INFO, "StateUpdatedWorker.simulateExposure");
 

--- a/android/src/main/java/ie/gov/tracing/nearby/StateUpdatedWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/StateUpdatedWorker.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationCompat.Builder;
 import androidx.core.app.NotificationManagerCompat;

--- a/android/src/main/java/ie/gov/tracing/nearby/StateUpdatedWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/StateUpdatedWorker.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationCompat.Builder;
 import androidx.core.app.NotificationManagerCompat;
@@ -247,6 +248,7 @@ public class StateUpdatedWorker extends ListenableWorker {
     showNotification(context);
   }
 
+   @RequiresApi(api = Build.VERSION_CODES.O)
    public static void simulateExposure(Long timeDelay) {
         Events.raiseEvent(Events.INFO, "StateUpdatedWorker.simulateExposure");
 


### PR DESCRIPTION
Updates the GMS dependencies to make the runtime not crash anymore

Note: the versions were taken from https://github.com/google/exposure-notifications-android/blob/master/app/build.gradle