### PR TITLE
Don't display an app badge number on checking keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ In order to upload/download diagnosis keys for exposure notifications, an applic
 ### Contributors
 
 * @moogster31 - Katie Roberts <katie@geekworld.co>
+* @AlanSl - Alan Slater <alan.slater@nearform.com>
 * TBD
 
 ### Past Contributors

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -216,6 +216,7 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
               .setProgress(1, 0, true)
               .setSmallIcon(R.mipmap.ic_notification)
               .setOngoing(true)
+              .setNumber(0)
               .build();
 
       return new ForegroundInfo(1, notification, FOREGROUND_SERVICE_TYPE_LOCATION);
@@ -228,6 +229,7 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
             id,
             this.context.getString(R.string.notification_channel_name), NotificationManager.IMPORTANCE_LOW
     );
+    channel.setShowBadge(false);
     NotificationManager notificationManager = (NotificationManager) this.context.getSystemService(
             Context.NOTIFICATION_SERVICE
     );

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -59,8 +59,10 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
   private static final String WORKER_NAME = "ProvideDiagnosisKeysWorker";
   private static final BaseEncoding BASE64_LOWER = BaseEncoding.base64();
   private static final int RANDOM_TOKEN_BYTE_LENGTH = 32;
-  private static final String FOREGROUND_NOTIFICATION_ID =
+  private static final String FOREGROUND_NOTIFICATION_ID_LEGACY =
           "ProvideDiagnosisKeysWorker.FOREGROUND_NOTIFICATION_ID";
+  private static final String FOREGROUND_NOTIFICATION_ID =
+          "ProvideDiagnosisKeysWorker.FOREGROUND_NOTIFICATION_ID.noBadge";
 
   private final DiagnosisKeyDownloader diagnosisKeys;
   private final DiagnosisKeyFileSubmitter submitter;
@@ -234,6 +236,7 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
             Context.NOTIFICATION_SERVICE
     );
     notificationManager.createNotificationChannel(channel);
+    notificationManager.deleteNotificationChannel(FOREGROUND_NOTIFICATION_ID_LEGACY);
   }
 
   private Result processFailure(Exception ex) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
In theory either `notification.setNumber(0);` or `channel.setShowBadge(false);` should be enough but in my testing on Samsung device (Note 8 / Android 9) `notification.setNumber(0);` didn't make any difference (although setting a non-zero number did change the number displayed). Apparently different Android launchers interpret the notification properties differently so it's best to use both.

Unfortunately creating a new channel to replace the old one is necessary else `channel.setShowBadge(false);` will make no difference for existing users (unless they re-install), because channel properties can only be edited by the user in settings after the channel is first created.