### PR TITLE
More reliably update exposureDisabledReason on Android bluetooth change

### DIFF
--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -115,7 +115,7 @@ object Tracing {
             if (BluetoothAdapter.ACTION_STATE_CHANGED == intent.action) {
                 if (isBluetoothAvailable()) {
                     if (newExposureDisabledReason == "bluetooth") {
-                        newExposureDisabledReason = "starting"
+                        newExposureDisabledReason = ""
                     }
                 } else {
                     newExposureDisabledReason = "bluetooth"
@@ -703,23 +703,19 @@ object Tracing {
                 if (!isBluetoothAvailable()) {
                     exposureStatus = EXPOSURE_STATUS_DISABLED
                     exposureDisabledReason = "bluetooth"
-                } else if (!isPaused) {
-                    if (exposureStatus == EXPOSURE_STATUS_ACTIVE) {
-                        exposureDisabledReason = ""
-                    } else {
-                        exposureDisabledReason = "starting"
-                    }
+                } else if (exposureDisabledReason == "bluetooth") {
+                    exposureDisabledReason = ""
                 }
 
                 result.putString("state", exposureStatus)
                 typeData.pushString(exposureDisabledReason)
-                result.putArray("type", typeData)                
+                result.putArray("type", typeData)
                 promise?.resolve(result)
             } catch (ex: Exception) {
                 Events.raiseError("getExposureStatus", ex)
                 result.putString("state", EXPOSURE_STATUS_UNKNOWN)
                 typeData.pushString("error")
-                result.putArray("type", typeData)                
+                result.putArray("type", typeData)
                 promise?.resolve(result)
             }
             return result

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -111,13 +111,32 @@ object Tracing {
     class BleStatusReceiver : BroadcastReceiver() {
 
         override fun onReceive(context: Context, intent: Intent) {
-
+            var newExposureDisabledReason = Tracing.exposureDisabledReason
             if (BluetoothAdapter.ACTION_STATE_CHANGED == intent.action) {
-                Tracing.getExposureStatus(null)
+                if (isBluetoothAvailable()) {
+                    if (newExposureDisabledReason == "bluetooth") {
+                        newExposureDisabledReason = "starting"
+                    }
+                } else {
+                    newExposureDisabledReason = "bluetooth"
+                }
             }
             Events.raiseEvent(Events.INFO, "bleStatusUpdate - $intent.action")
-            Tracing.setExposureStatus(Tracing.exposureStatus, Tracing.exposureDisabledReason)
+            Tracing.setExposureStatus(Tracing.exposureStatus, newExposureDisabledReason)
         }
+    }
+
+    private fun isBluetoothAvailable(): Boolean {
+        val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter();
+
+        if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled) {
+            return false
+        }
+
+        if (isLocationEnableRequired()) {
+            return false
+        }
+        return true
     }
 
     lateinit var context: Context
@@ -679,18 +698,18 @@ object Tracing {
             if (isPaused) {
                 exposureDisabledReason = "paused"
             }
-            try {
-                // check bluetooth
-                val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter();
-                if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled) {
-                    exposureStatus = EXPOSURE_STATUS_DISABLED
-                    exposureDisabledReason = "bluetooth";
-                }
 
-                if (isLocationEnableRequired()) {
+            try {
+                if (!isBluetoothAvailable()) {
                     exposureStatus = EXPOSURE_STATUS_DISABLED
-                    exposureDisabledReason = "bluetooth";
-                }                
+                    exposureDisabledReason = "bluetooth"
+                } else if (!isPaused) {
+                    if (exposureStatus == EXPOSURE_STATUS_ACTIVE) {
+                        exposureDisabledReason = ""
+                    } else {
+                        exposureDisabledReason = "starting"
+                    }
+                }
 
                 result.putString("state", exposureStatus)
                 typeData.pushString(exposureDisabledReason)


### PR DESCRIPTION
Investigating https://github.com/covid-alert-ny/covid-green-app/issues/563 on Android I found everything seemed fine on the app side but when ENS was off, the RNENS disabled reason status wasn't changing on enabling bluetooth giving misleading messages.

Problem seemed to be in `tracing.kt`:

- `getExposureStatus` can set `"bluetooth"` as the `exposureDisabledReason` but didn't have anything to unset it when enabled - if `"bluetooth"` was the reason but no longer is, it'll still return the old `"bluetooth"` value 
- The way the Bluetooth state listener calls `setExposureStatus` sometimes fails because calling `getExposureStatus` to get the new bluetooth state modifies the `exposureDisabledReason`, which `setExposureStatus` then compares to the new value to see if it has changed - incorrectly not calling the change event because it treats the just-changed `exposureDisabledReason` variable as the old value.

This makes `getExposureStatus()` not return `"bluetooth"` as the `exposureDisabledReason` if bluetooth is now active and makes the Bluetooth state listener not change the `exposureDisabledReason` variable before calling `setExposureStatus`.

