### PR TITLE
🔥🐛🔥 Fix infinite loop on unsupported android devices 🔥🐛🔥

### DIFF
--- a/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
+++ b/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
@@ -193,7 +193,7 @@ public class ExposureNotificationModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void status(Promise promise) {
         if(nearbyNotSupported()) {
-            Tracing.setExposureStatus("unavailable", "apiError: " + apiError);
+            Tracing.setExposureStatus("unavailable", "apiError: " + apiError, false);
         }
         Tracing.getExposureStatus(promise);
     }

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -150,7 +150,7 @@ object Tracing {
         private var extraDetails = false
 
         @JvmStatic
-        fun setExposureStatus(status: String, reason: String = "") {
+        fun setExposureStatus(status: String, reason: String = "", skipEvents: Boolean = false) {
             if (exposureStatus == EXPOSURE_STATUS_UNAVAILABLE) {
                 return;
             }
@@ -163,7 +163,7 @@ object Tracing {
                 exposureDisabledReason = reason
                 changed = true
             }
-            if (changed) {
+            if (!skipEvents && changed) {
                 Events.raiseEvent(Events.ON_STATUS_CHANGED, getExposureStatus(null))
             }
         }
@@ -686,11 +686,11 @@ object Tracing {
                 // check bluetooth
                 val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter();
                 if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled) {
-                    setExposureStatus(EXPOSURE_STATUS_DISABLED, "bluetooth");
+                    setExposureStatus(EXPOSURE_STATUS_DISABLED, "bluetooth", true);
                 }
 
                 if (isLocationEnableRequired()) {
-                    setExposureStatus(EXPOSURE_STATUS_DISABLED, "bluetooth");
+                    setExposureStatus(EXPOSURE_STATUS_DISABLED, "bluetooth", true);
                 }                
 
                 result.putString("state", exposureStatus)

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -151,6 +151,9 @@ object Tracing {
 
         @JvmStatic
         fun setExposureStatus(status: String, reason: String = "") {
+            if (exposureStatus == EXPOSURE_STATUS_UNAVAILABLE) {
+                return;
+            }
             var changed = false
             if (exposureStatus != status) {
                 exposureStatus = status
@@ -683,13 +686,11 @@ object Tracing {
                 // check bluetooth
                 val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter();
                 if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled) {
-                    exposureStatus = EXPOSURE_STATUS_DISABLED
-                    exposureDisabledReason = "bluetooth";
+                    setExposureStatus(EXPOSURE_STATUS_DISABLED, "bluetooth");
                 }
 
                 if (isLocationEnableRequired()) {
-                    exposureStatus = EXPOSURE_STATUS_DISABLED
-                    exposureDisabledReason = "bluetooth";
+                    setExposureStatus(EXPOSURE_STATUS_DISABLED, "bluetooth");
                 }                
 
                 result.putString("state", exposureStatus)

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -170,7 +170,8 @@ object Tracing {
 
         @JvmStatic
         fun setExposureStatus(status: String, reason: String = "", skipEvents: Boolean = false) {
-            if (exposureStatus == EXPOSURE_STATUS_UNAVAILABLE) {
+            // cannot transition again after handling ExposureNotificationStatusCodes.API_NOT_CONNECTED
+            if (exposureStatus == EXPOSURE_STATUS_UNAVAILABLE && exposureDisabledReason == "not_connected") {
                 return;
             }
             var changed = false


### PR DESCRIPTION
There seems to be a bug where ExposureProvider freezes android devices without google play store by default (one of the chinese phones). Replicated on my Redmi 7.

Upon further investigation, it seems that there is an edge case in the android code that could create an infinite loop:

in Tracing.kt:

upon initialization, on an unsupported device:

`func getExposureStatus` sets status to `disabled`
`exposureWrapper.isEnabled` throws `ExposureNotificationStatusCodes.API_NOT_CONNECTED`, which sets the status to unavailable
this triggers a onStatusChanged event, as the status changed from disabled -> unavailable
`ExposureProvider` listens to `exposureEvent`, calls `validateStatus`, which triggers another `getExposureStatus` and ` exposureEnabled` and so on, creating an infinite loop.

Attempted a fix so `setExposureStatus` no longer changes the status if it's `unavailable`. the assumption being it shouldn't transition again if already `unavailable`

attached logs:
[logs.txt](https://github.com/covidgreen/react-native-exposure-notification-service/files/5593469/logs.txt)