### PR TITLE
Fix missing model items

### DIFF
--- a/ios/ExposureNotification.xcdatamodeld/Settings.xcdatamodel/contents
+++ b/ios/ExposureNotification.xcdatamodeld/Settings.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19H15" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="19H15" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Exposures" representedClassName="Exposures" syncable="YES" codeGenerationType="class">
         <attribute name="attenuations" optional="YES" attributeType="String"/>
         <attribute name="customAttenuationDurations" optional="YES" attributeType="String"/>
@@ -13,6 +13,7 @@
     </entity>
     <entity name="Settings" representedClassName="Settings" syncable="YES" codeGenerationType="class">
         <attribute name="analyticsOptin" optional="YES" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="authToken" optional="YES" attributeType="String"/>
         <attribute name="checkExposureInterval" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="dailyTrace" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="datesLastRan" optional="YES" attributeType="String"/>
@@ -28,6 +29,7 @@
         <attribute name="notificationRaised" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="notificationRepeat" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="notificationTitle" optional="YES" attributeType="String"/>
+        <attribute name="refreshToken" optional="YES" attributeType="String"/>
         <attribute name="serverURL" optional="YES" attributeType="String"/>
         <attribute name="servicePaused" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="serviceStopped" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -36,6 +38,6 @@
     </entity>
     <elements>
         <element name="Exposures" positionX="-54" positionY="-9" width="128" height="178"/>
-        <element name="Settings" positionX="-63" positionY="-18" width="128" height="358"/>
+        <element name="Settings" positionX="-63" positionY="-18" width="128" height="388"/>
     </elements>
 </model>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.42",
+  "version": "1.1.43",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
For certain fallback error scenario the refresh token and auth tokens can be saved in model data storage. Two keys were missing, this PR adds them