### PR TITLE
Fix handling when ENS is not available

### DIFF
--- a/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
+++ b/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
@@ -21,7 +21,7 @@ public class ExposureNotificationModule extends ReactContextBaseJavaModule {
     private static int apiError = 0;
 
     public boolean nearbyNotSupported(){
-        return false;
+        return !Tracing.isENSSupported();
     }
 
     // after update performed this should be called

--- a/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
+++ b/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
@@ -205,7 +205,7 @@ public class ExposureNotificationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void canSupport(Promise promise) {
-        promise.resolve(true);
+        Tracing.canSupport(promise);
     }
 
     @ReactMethod

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -123,8 +123,10 @@ object Tracing {
                     newStatus = Tracing.EXPOSURE_STATUS_DISABLED
                 }
             }
-            Events.raiseEvent(Events.INFO, "bleStatusUpdate - $intent.action")
-            Tracing.setExposureStatus(newStatus, newExposureDisabledReason)
+            Events.raiseEvent(Events.INFO, "bleStatusUpdate - $intent.action, $doesSupportENS")
+            if (doesSupportENS) {
+                Tracing.setExposureStatus(newStatus, newExposureDisabledReason)
+            }            
         }
     }
 

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -572,10 +572,10 @@ object Tracing {
 
                 try {
                     val apiResult = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
-                    Events.raiseEvent(Events.INFO, "isSupported - checkAvailability: $apiResult")
+                    Events.raiseEvent(Events.INFO, "isSupported - isGooglePlayServicesAvailable: $apiResult")
                     if (apiResult == ConnectionResult.SUCCESS) {
-                        val version = ExposureNotificationHelper.checkAvailability().await()
-                        Events.raiseEvent(Events.INFO, "isSupported - version: $version")
+                        val version = ExposureNotificationHelper.getDeviceENSVersion().await()
+                        Events.raiseEvent(Events.INFO, "isSupported - getDeviceENSVersion: $version")
                         doesSupportENS = true
                         promise.resolve(true)
                     } else if (apiResult == ConnectionResult.SERVICE_INVALID || apiResult == ConnectionResult.SERVICE_DISABLED || apiResult == ConnectionResult.SERVICE_MISSING) {

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -558,6 +558,13 @@ object Tracing {
         }
 
         @JvmStatic
+        fun canSupport(promise: Promise) {
+            val apiResult = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+            Events.raiseEvent(Events.INFO, "GMS - isAvailable: $apiResult")
+            promise.resolve(apiResult == ConnectionResult.SUCCESS)
+        }
+
+        @JvmStatic
         fun isSupported(promise: Promise) = runBlocking<Unit> {
             launch {
 

--- a/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationClientWrapper.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationClientWrapper.java
@@ -98,6 +98,10 @@ public class ExposureNotificationClientWrapper {
     return exposureNotificationClient.deviceSupportsLocationlessScanning();
   }
   
+  public Task<Long> deviceSupportsENS() {
+    return exposureNotificationClient.getVersion();
+  }
+    
   /*
   Task<List<ExposureInformation>> getExposureInformation(String token) {
     return exposureNotificationClient.getExposureInformation(token);

--- a/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationClientWrapper.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationClientWrapper.java
@@ -98,7 +98,7 @@ public class ExposureNotificationClientWrapper {
     return exposureNotificationClient.deviceSupportsLocationlessScanning();
   }
   
-  public Task<Long> deviceSupportsENS() {
+  public Task<Long> getDeviceENSVersion() {
     return exposureNotificationClient.getVersion();
   }
     

--- a/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationHelper.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationHelper.java
@@ -5,8 +5,6 @@ import ie.gov.tracing.common.Events;
 import ie.gov.tracing.Tracing;
 import ie.gov.tracing.common.AppExecutors;
 import ie.gov.tracing.common.TaskToFutureAdapter;
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.nearby.Nearby;
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -112,7 +110,11 @@ public class ExposureNotificationHelper implements LifecycleObserver {
         AppExecutors.getScheduledExecutor());
   }
 
-  public static int checkAvailability() {
-    return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(Tracing.reactContext);
+  public static ListenableFuture<Long> checkAvailability() {
+    return TaskToFutureAdapter.getFutureWithTimeout(
+            ExposureNotificationClientWrapper.get(Tracing.reactContext).deviceSupportsENS(),
+            API_TIMEOUT.toMillis(),
+            TimeUnit.MILLISECONDS,
+            AppExecutors.getScheduledExecutor());
   }
 }

--- a/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationHelper.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ExposureNotificationHelper.java
@@ -110,9 +110,9 @@ public class ExposureNotificationHelper implements LifecycleObserver {
         AppExecutors.getScheduledExecutor());
   }
 
-  public static ListenableFuture<Long> checkAvailability() {
+  public static ListenableFuture<Long> getDeviceENSVersion() {
     return TaskToFutureAdapter.getFutureWithTimeout(
-            ExposureNotificationClientWrapper.get(Tracing.reactContext).deviceSupportsENS(),
+            ExposureNotificationClientWrapper.get(Tracing.reactContext).getDeviceENSVersion(),
             API_TIMEOUT.toMillis(),
             TimeUnit.MILLISECONDS,
             AppExecutors.getScheduledExecutor());

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.1.43",
+  "version": "1.1.44",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
In the case where ENS is not on a device and bluetooth is off an infinite loop occurs. This happens as the status gets set to unavailable as a result of ENS not being available but when bluetooth is check it changes the state to disabled. The event that raises the state change triggers a refresh of the state check which results in it getting set back to unavailable and this cycle continues.
To fix this the check for isSupported has been corrected. The current version was only checking if GMS was on the device rather than checking for ENS. The new check does both.
If ENS is not supported then calls to isAuthorised etc are all skipped. This avoids the loop above from happening.
As an additional check state can only be set to disabled is ENS is supported to again avoid spurious state changes.
