### PR TITLE
Android "checking exposure keys" notification sometimes displays forever (until restart)

### DIFF
--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -127,14 +127,18 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
   @NonNull
   @Override
   public ListenableFuture<Result> startWork() {
+    return FluentFuture
+            .from(setForegroundAsync(createForegroundInfo()))
+            .transformAsync(result -> {return _startWork();}, AppExecutors.getScheduledExecutor());
+  }
+
+  public ListenableFuture<Result> _startWork() {
       try {
         Tracing.currentContext = this.context;
         Events.raiseEvent(Events.INFO, "ProvideDiagnosisKeysWorker.startWork");
         SharedPrefs.remove("lastApiError", this.context);
         SharedPrefs.remove("lastError", this.context);
         final boolean skipTimeCheck = getInputData().getBoolean("skipTimeCheck", false);
-
-        setForegroundAsync(createForegroundInfo());
   
         /*long lastRun = SharedPrefs.getLong("lastRunDate", Tracing.currentContext);
         long checkFrequency = SharedPrefs.getLong("exposureCheckFrequency", Tracing.context);


### PR DESCRIPTION
This is hard to replicate but quite prevalent in our play store reviews (NZ Covid tracer app), with about 75 reviews around the "checking exposure keys" notification displaying forever.

from reddit:
https://www.reddit.com/r/newzealand/comments/kco8d1/covid_tracer_app_constantly_checking_exposure/
https://www.reddit.com/r/newzealand/comments/kc3dzr/is_anyones_covid_tracer_app_doing_this/

found a possible cause for this issue, from the documentation [ListenableWorker#setForegroundAsync](https://developer.android.com/reference/androidx/work/ListenableWorker#setForegroundAsync(androidx.work.ForegroundInfo)) 

> Calls to setForegroundAsync *must* complete before a ListenableWorker signals completion by returning a ListenableWorker.Result.

also, found this on google issue tracker: https://issuetracker.google.com/issues/150800856, 
where the recommended fix is to wait for setForegroundAsync to finish, before running the rest of the worker.

we've been able to replicate the error state by forcing the worker to return before setForegroundAsync, with the following code:

```
startWork() {
  Futures.scheduleAsync(new AsyncCallable<Void>() {
    @Override
    public ListenableFuture<Void> call() {
      return setForegroundAsync(createForegroundInfo());
    }
  }, 5, TimeUnit.SECONDS, AppExecutors.getScheduledExecutor());
}
```

Our guess is that the cause is a race condition where sometimes the job completes before setForegroundAsync.  

This is an attempted fix, any insights/suggestion on possible causes would be greatly appreciated 👍 @colmharte 

NOTE: we were able to replicate this with both `1.1.44`(public release) `1.2.1`
