### PR TITLE
Android - Keep existing policy if check frequency is the same

### DIFF
--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -681,7 +681,6 @@ object Tracing {
         private fun scheduleCheckExposure() {
             try {
                 // stop and re-start with config value
-                ProvideDiagnosisKeysWorker.stopScheduler()
                 ProvideDiagnosisKeysWorker.startScheduler()
             } catch (ex: Exception) {
                 Events.raiseError("scheduleCheckExposure", ex)

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -355,8 +355,13 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
                             .setRequiredNetworkType(NetworkType.CONNECTED)
                             .build())
             .build();
+    long scheduledCheckFrequency = SharedPrefs.getLong("scheduledExposureCheckFrequency", Tracing.context);
+    ExistingPeriodicWorkPolicy policy = scheduledCheckFrequency == 0 || checkFrequency != scheduledCheckFrequency
+            ? ExistingPeriodicWorkPolicy.REPLACE
+            : ExistingPeriodicWorkPolicy.KEEP;
     workManager
-            .enqueueUniquePeriodicWork(WORKER_NAME, ExistingPeriodicWorkPolicy.REPLACE, workRequest);
+            .enqueueUniquePeriodicWork(WORKER_NAME, policy, workRequest);
+    SharedPrefs.setLong("scheduledExposureCheckFrequency", checkFrequency, Tracing.context);
   }
 
 

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -362,6 +362,7 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
     workManager
             .enqueueUniquePeriodicWork(WORKER_NAME, policy, workRequest);
     SharedPrefs.setLong("scheduledExposureCheckFrequency", checkFrequency, Tracing.context);
+    Events.raiseEvent(Events.INFO, "ProvideDiagnosisKeysWorker.startScheduler: policy " + policy);
   }
 
 


### PR DESCRIPTION
Currently `scheduleCheckExposure` would restart the periodic worker every time a user opens the app (through `Tracing.kt #init`).

For us, our app does some background processing after silent push notifications, the app is woken up, which triggers the initialization code from the module and schedules another check. This causes a spike in backend traffic.

Made a change so it only replaces the job if `checkFrequency` changes, and behaves the same as iOS

There might be some caveats we missed around Android worker scheduling. @colmharte please review, thanks