### PR TITLE
Bump work manager to 2.5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
 
     // WorkManager
-    def work_version = "2.4.0"
+    def work_version = "2.5.0"
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.work:work-runtime-ktx:$work_version"
     implementation "androidx.work:work-rxjava2:$work_version"


### PR DESCRIPTION
Bumping WorkManager to the latest stable version [2.5.0](https://developer.android.com/jetpack/androidx/releases/work#2.5.0) to improve the reliability of running background jobs on Android devices

