### PR TITLE
Bluetooth fix

### DIFF
--- a/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
+++ b/android/src/main/java/ie/gov/tracing/ExposureNotificationModule.java
@@ -193,7 +193,7 @@ public class ExposureNotificationModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void status(Promise promise) {
         if(nearbyNotSupported()) {
-            Tracing.setExposureStatus("unavailable", "apiError: " + apiError);
+            Tracing.setExposureStatus("unavailable", "apiError: " + apiError, false);
         }
         Tracing.getExposureStatus(promise);
     }

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -176,7 +176,7 @@ object Tracing {
         var startPromise: Promise? = null
 
         @JvmStatic
-        fun setExposureStatus(status: String, reason: String = "") {
+        fun setExposureStatus(status: String, reason: String = "", scheduleCheck: Boolean = false) {
             var changed = false
             if (exposureStatus != status) {
                 exposureStatus = status

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -37,6 +37,8 @@ import ie.gov.tracing.storage.SharedPrefs
 import ie.gov.tracing.storage.SharedPrefs.Companion.getLong
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.*
+import kotlin.concurrent.schedule
 
 object Tracing {
     class Listener: ActivityEventListener {
@@ -126,7 +128,7 @@ object Tracing {
             }
             Events.raiseEvent(Events.INFO, "bleStatusUpdate - $intent.action, $doesSupportENS")
             if (doesSupportENS) {
-                Tracing.setExposureStatus(newStatus, newExposureDisabledReason)
+                Tracing.setExposureStatus(newStatus, newExposureDisabledReason, true)
             }            
         }
     }
@@ -185,8 +187,14 @@ object Tracing {
                 changed = true
             }
             if (changed) {
-                Events.raiseEvent(Events.ON_STATUS_CHANGED, getExposureStatus(null))
-            }
+                if (scheduleCheck) {
+                    Timer("DelayedENSCheck", false).schedule(300) {
+                        Events.raiseEvent(Events.ON_STATUS_CHANGED, getExposureStatus(null))
+                    }
+                } else {
+                    Events.raiseEvent(Events.ON_STATUS_CHANGED, getExposureStatus(null))
+                }
+            }                
         }
 
         @JvmStatic

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -776,7 +776,8 @@ object Tracing {
         fun getExposureStatus(promise: Promise? = null): ReadableMap = runBlocking {
             val result: WritableMap = Arguments.createMap()
             val typeData: WritableArray = Arguments.createArray()
-
+            var enabled = false
+            
             try {
                 enabled = ExposureNotificationHelper.isEnabled().await()
             } catch(ex: Exception) {

--- a/android/src/main/java/ie/gov/tracing/Tracing.kt
+++ b/android/src/main/java/ie/gov/tracing/Tracing.kt
@@ -769,7 +769,11 @@ object Tracing {
             val result: WritableMap = Arguments.createMap()
             val typeData: WritableArray = Arguments.createArray()
 
-            val enabled = ExposureNotificationHelper.isEnabled().await()
+            try {
+                enabled = ExposureNotificationHelper.isEnabled().await()
+            } catch(ex: Exception) {
+                Events.raiseError("Error reading ENS status", ex)
+            }
             val isPaused = SharedPrefs.getBoolean("servicePaused", context)
             if (doesSupportENS && isPaused && !enabled) {
                 exposureStatus = EXPOSURE_STATUS_DISABLED

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
The call to isEnabled that happens during a bluetooth status change event is timing out. This was triggered by the upgrade to v 1.8.3 of the exposure notification sdk.
The fix involves delaying the call to isEnabled