### PR TITLE
Add configuration to hide foreground notifications (Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Use to configure the module. This method is synchronous, and should be called be
 - `notificationDesc`: a string representing the description for positive exposure notifications popup,
 - `callbackNumber`: a string representing the phone number of a user if opted into automatic callback on positive exposure notification,
 - `analyticsOptin`: a boolean representing whether the user opted in or not
+- `hideForeground`: Android only. a boolean representing whether to hide foreground notifications
 
 ---
 

--- a/android/src/main/java/ie/gov/tracing/common/Config.kt
+++ b/android/src/main/java/ie/gov/tracing/common/Config.kt
@@ -39,6 +39,7 @@ object Config {
             SharedPrefs.setString("lastUpdated", ran, Tracing.context)
             SharedPrefs.setLong("notificationRepeat", params.getInt("notificationRepeat").toLong(), Tracing.context)
             SharedPrefs.setString("certList", params.getString("certList")!!, Tracing.context)
+            SharedPrefs.setBoolean("hideForeground", params.getBoolean("hideForeground")!!, Tracing.context)
 
         } catch (ex: Exception) {
             Events.raiseError("Error setting configuration: ", ex)

--- a/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
+++ b/android/src/main/java/ie/gov/tracing/nearby/ProvideDiagnosisKeysWorker.java
@@ -128,6 +128,15 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
   @NonNull
   @Override
   public ListenableFuture<Result> startWork() {
+      // validate config set before running
+      final String server = SharedPrefs.getString("serverUrl", this.context);
+      if (server.isEmpty()) {
+        // config not yet populated so don't run
+        SharedPrefs.setString("lastError", "No config set so can't proceed with checking exposures", this.context);
+        Events.raiseEvent(Events.INFO, "No config set so can't proceed with checking exposures");
+        return Futures.immediateFuture(Result.success());
+      }
+
       boolean hideForeground = SharedPrefs.getBoolean("hideForeground", this.context);
       try {
         if (!hideForeground) {
@@ -157,15 +166,6 @@ public class ProvideDiagnosisKeysWorker extends ListenableWorker {
         */
 
         updateLastRun();
-
-        // validate config set before running
-        final String server = SharedPrefs.getString("serverUrl", this.context);
-        if (server.isEmpty()) {
-          // config not yet populated so don't run
-          SharedPrefs.setString("lastError", "No config set so can't proceed with checking exposures", this.context);
-          Events.raiseEvent(Events.INFO, "No config set so can't proceed with checking exposures");
-          return Futures.immediateFuture(Result.success());
-        }
 
         saveDailyMetric();
 

--- a/src/__tests__/exposure-provider.test.tsx
+++ b/src/__tests__/exposure-provider.test.tsx
@@ -109,7 +109,8 @@ const mockConfig = {
   analyticsOptin: true,
   callbackNumber: '0123456789',
   notificationRepeat: 0,
-  certList: 'cert12'
+  certList: 'cert12',
+  hideForeground: true
 };
 
 const ExposureProviderWithMockConfig: React.FC<Partial<
@@ -221,7 +222,8 @@ describe('<ExposureProvider />', () => {
       keyServerType: mockConfig.keyServerType,
       storeExposuresFor: mockConfig.traceConfiguration.storeExposuresFor,
       notificationRepeat: mockConfig.notificationRepeat,
-      certList: mockConfig.certList
+      certList: mockConfig.certList,
+      hideForeground: mockConfig.hideForeground
     });
   });
 
@@ -400,7 +402,8 @@ describe('useExposure', () => {
         keyServerType: mockConfig.keyServerType,
         storeExposuresFor: mockConfig.traceConfiguration.storeExposuresFor,
         notificationRepeat: mockConfig.notificationRepeat,
-        certList: mockConfig.certList
+        certList: mockConfig.certList,
+        hideForeground: mockConfig.hideForeground
       });
     });
 
@@ -687,7 +690,8 @@ describe('useExposure', () => {
         1
       );
       expect(ExposureNotificationModule.simulateExposure).toHaveBeenCalledWith(
-        10, 4
+        10,
+        4
       );
     });
   });

--- a/src/exposure-notification-module.ts
+++ b/src/exposure-notification-module.ts
@@ -28,6 +28,7 @@ export interface ConfigurationOptions {
   analyticsOptin: boolean;
   notificationRepeat: number;
   certList: string;
+  hideForeground?: boolean;
 }
 
 export interface DiagnosisKey {

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -163,7 +163,7 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   analyticsOptin = false,
   notificationRepeat = 0,
   certList = '',
-  hideForeground
+  hideForeground = false
 }) => {
   const [state, setState] = useState<State>(initialState);
 
@@ -199,13 +199,12 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
     async function checkSupportAndStart() {
       await supportsExposureApi();
 
-      await configure();
-
       // Start as soon as we're able to
       if (
         isReady &&
         state.permissions.exposure.status === PermissionStatus.Allowed
       ) {
+        await configure();
         const latestStatus = await ExposureNotification.status();
 
         if (

--- a/src/exposure-provider.tsx
+++ b/src/exposure-provider.tsx
@@ -118,6 +118,7 @@ export interface ExposureProviderProps {
   analyticsOptin?: boolean;
   notificationRepeat?: number;
   certList?: string;
+  hideForeground?: boolean;
 }
 
 export const getVersion = async () => {
@@ -161,7 +162,8 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
   callbackNumber = '',
   analyticsOptin = false,
   notificationRepeat = 0,
-  certList = ''
+  certList = '',
+  hideForeground
 }) => {
   const [state, setState] = useState<State>(initialState);
 
@@ -197,12 +199,13 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
     async function checkSupportAndStart() {
       await supportsExposureApi();
 
+      await configure();
+
       // Start as soon as we're able to
       if (
         isReady &&
         state.permissions.exposure.status === PermissionStatus.Allowed
       ) {
-        await configure();
         const latestStatus = await ExposureNotification.status();
 
         if (
@@ -311,7 +314,8 @@ export const ExposureProvider: React.FC<ExposureProviderProps> = ({
         callbackNumber,
         analyticsOptin,
         notificationRepeat,
-        certList
+        certList,
+        hideForeground
       };
       await ExposureNotification.configure(config);
 


### PR DESCRIPTION
hi @colmharte would appreciate your help again

We are still getting some feedback from Playstore (NZ COVID Tracer App 3.0.2) that the notification stuck issue is still occuring:

> Constantly stuck checking exposure keys on my s10. Chewing through battery 5% in 10 min at this rate my battery will be flat in just over 3 hours. If this can be fixed will need to delete app.

> Still getting the infinite checking keys bug. Apart from that it seems to do what it's supposed to.

It seems that workers with a FGS do not have a timeout, while normal workers do timeout after 10 min

Added a configuration to hide foreground notifications altogether

