### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-exposure-notification-service",
   "title": "React Native Exposure Notification Service",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "React native module providing a common interface to Apple/Google's Exposure Notification APIs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
please bump version for https://github.com/covidgreen/react-native-exposure-notification-service/pull/72 and possibly https://github.com/covidgreen/react-native-exposure-notification-service/pull/73